### PR TITLE
bug fixed for verifying active key

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1569,6 +1569,15 @@ router.post('/api/completeIdentityChallenge', middleware.requireLogin, async (re
                 signatureValid = true;
               }
         }
+        for (let auth of account.active.key_auths) {
+            const sigValidity = dhive.PublicKey.fromString(auth[0]).verify(
+                Buffer.from(dhive.cryptoUtils.sha256(message)),
+                dhive.Signature.fromBuffer(Buffer.from(signature, 'hex')),
+              )
+              if (sigValidity) {
+                signatureValid = true;
+              }
+        }
 
         if (signatureValid) {
             const challenge = await mongoDB.HiveAccountChallenge.findOne({


### PR DESCRIPTION
While adding an account with Private-Active-key, it used to throw error as follows.

![Captura_de_pantalla_2024-02-13_112936](https://github.com/spknetwork/3speak-legacy-studio/assets/4737312/44d6cf3f-cfb3-401e-955d-3d382959f525)

This issue is now fixed with this Pull-request.