### PR TITLE
temporary check for beneficiary

### DIFF
--- a/routes/mobile/middleware-mobile.js
+++ b/routes/mobile/middleware-mobile.js
@@ -127,14 +127,14 @@ async function hasValidPostBeneficiariesAndPayout(author, permlink) {
         spkBeneficiaryWeight === null
       )
         return false;
-      if (sagarBenWeight < 100 || spkBeneficiaryWeight < 1000) return false;
+      if (sagarBenWeight < 100 || spkBeneficiaryWeight < 900) return false;
       return true;
     } else {
       if (spkBeneficiary.length === 0) return false;
       const spkBeneficiaryWeight = spkBeneficiary[0].weight;
       if (spkBeneficiaryWeight === undefined || spkBeneficiaryWeight === null)
         return false;
-      if (spkBeneficiaryWeight < 1000) return false;
+      if (spkBeneficiaryWeight < 900) return false;
       return true;
     }
   } catch (e) {


### PR DESCRIPTION
- Ecency & ActiFit has not yet added the changes for removal of `threespeakleader`
- So, they are yet publishing the video with that beneficiary.
- Due to this, beneficiary check (after post is published) is failing
- Upon failing video gets marked as `encoding_failed` which is correct but only after actifit & Ecency is done integrating it.
- So, for now, keeping this temporary beneficiary check to avoid `encoding_failed`